### PR TITLE
리팩토링: 노드 CUD 기능 리팩토링

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@
 
 ### 구현 현황
 
-- [X] 메인 페이지 디자인, 구현
+- [x] 메인 페이지 디자인, 구현
 - [ ] 그래프 CRUD 기능(추가 기능 완성)
 - [ ] Local Storage에 데이터 저장
 - [ ] 마인드 맵 export 기능 구현
@@ -27,14 +27,15 @@
 
 - React
 - JavaScript
-- Styled-Component
-- Styled-reset
-- React-Router-Dom
 - Cytoscape(Cytoscape / react-cytoscape)
+- recoil
+- Styled-Component, Styled-reset
+- React-Router-Dom
 
 ## 핵심 기능
 
 - 그래프 표현(cytoscape)
+
   - [cytoscape](https://js.cytoscape.org/)
   - [react-cytoscape](https://github.com/plotly/react-cytoscapejs)
 

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "react-dom": "^17.0.2",
     "react-router-dom": "^6.0.2",
     "react-scripts": "4.0.3",
+    "recoil": "^0.5.2",
     "styled-components": "^5.3.3",
     "styled-reset": "^4.3.4",
     "web-vitals": "^1.0.1"

--- a/src/App.js
+++ b/src/App.js
@@ -1,14 +1,17 @@
 import { Route, Routes } from 'react-router-dom';
+import { RecoilRoot } from 'recoil';
 
 import Home from './page/Home';
 import MindMap from './page/MindMap';
 
 const App = () => {
   return (
-    <Routes>
-      <Route path='/' element={<Home />} />
-      <Route path='/mindmap' element={<MindMap />} />
-    </Routes>
+    <RecoilRoot>
+      <Routes>
+        <Route path='/' element={<Home />} />
+        <Route path='/mindmap' element={<MindMap />} />
+      </Routes>
+    </RecoilRoot>
   );
 };
 

--- a/src/components/CytoscapeControl.js
+++ b/src/components/CytoscapeControl.js
@@ -1,5 +1,5 @@
 /* eslint-disable no-console */
-import { useState, useEffect, useRef } from 'react';
+import { useState, useEffect, useRef, useCallback } from 'react';
 import { useRecoilState, useRecoilValue } from 'recoil';
 import styled from 'styled-components';
 
@@ -73,19 +73,23 @@ const CytoscapeControl = ({ cyRef }) => {
     nodeIdCounter.current += 1;
   };
 
-  useEffect(() => {
-    const cy = cyRef.current;
-    // 노드 클릭 이벤트
-    const nodeClickHandler = (e) => {
+  // 노드 클릭 이벤트
+  const nodeClickHandler = useCallback(
+    (e) => {
       const node = e.target;
       setNodeId(node.id());
-    };
+    },
+    [setNodeId],
+  );
+
+  useEffect(() => {
+    const cy = cyRef.current;
     if (inputType) {
       cy.on('tap', 'node', nodeClickHandler);
     } else {
       cy.removeListener('tap', nodeClickHandler);
     }
-  }, [cyRef, inputType, setNodeId, setTargetNode]);
+  }, [cyRef, inputType, nodeClickHandler]);
 
   return (
     <ControlContainer>
@@ -113,6 +117,7 @@ const CytoscapeControl = ({ cyRef }) => {
             countNodeIdCounter={countNodeIdCounter}
             onChangeTargetNode={onChangeTargetNode}
             initTargetNode={initTargetNode}
+            nodeClickHandler={nodeClickHandler}
           />
         )}
         {currentMode === 'delete' && (

--- a/src/components/CytoscapeControl.js
+++ b/src/components/CytoscapeControl.js
@@ -81,10 +81,8 @@ const CytoscapeControl = ({ cyRef }) => {
       setNodeId(node.id());
     };
     if (inputType) {
-      // console.log('추가');
       cy.on('tap', 'node', nodeClickHandler);
     } else {
-      // console.log('삭제');
       cy.removeListener('tap', nodeClickHandler);
     }
   }, [cyRef, inputType, setNodeId, setTargetNode]);
@@ -133,9 +131,6 @@ const CytoscapeControl = ({ cyRef }) => {
             cyRef={cyRef}
             nodeId={nodeId}
             onChangeNodeId={onChangeNodeId}
-            targetNode={targetNode}
-            onChangeTargetNode={onChangeTargetNode}
-            initTargetNode={initTargetNode}
           />
         )}
       </div>

--- a/src/components/CytoscapeControl.js
+++ b/src/components/CytoscapeControl.js
@@ -1,6 +1,11 @@
-import { useState } from 'react';
+import { useState, useEffect, useRef } from 'react';
+import { useRecoilState } from 'recoil';
 import styled from 'styled-components';
 
+import {
+  nodeInputState,
+  targetNodeInputState,
+} from './globalState/nodeControl';
 import NodeCreate from './graphControls/NodeCreate';
 import NodeDelete from './graphControls/NodeDelete';
 import NodeUpdate from './graphControls/NodeUpdate';
@@ -34,10 +39,33 @@ const CytoscapeControl = ({ cyRef }) => {
     { name: '삭제', mode: 'delete' },
   ]);
   const [currentMode, setCurrentMode] = useState('create');
+  // const [newNode, setNewNode] = useRecoilState(nodeInputState);
+  const [targetNode, setTargetNode] = useRecoilState(targetNodeInputState);
+  const nodeIdCounter = useRef(5);
+
+  const initTargetNode = () => {
+    setTargetNode('');
+  };
+
+  const onChangeTargetNode = (e) => {
+    setTargetNode(e.target.value);
+  };
 
   const handleMode = (mode) => {
     setCurrentMode(mode);
   };
+
+  const countNodeIdCounter = () => {
+    nodeIdCounter.current += 1;
+  };
+
+  useEffect(() => {
+    // 노드 클릭 이벤트
+    cyRef.current.on('tap', 'node', (e) => {
+      const node = e.target;
+      setTargetNode(node.id());
+    });
+  }, [cyRef, setTargetNode]);
 
   return (
     <ControlContainer>
@@ -54,9 +82,27 @@ const CytoscapeControl = ({ cyRef }) => {
         </ControlCategory>
       </div>
       <div>
-        {currentMode === 'create' && <NodeCreate cyRef={cyRef} />}
-        {currentMode === 'delete' && <NodeDelete cyRef={cyRef} />}
-        {currentMode === 'update' && <NodeUpdate cyRef={cyRef} />}
+        {currentMode === 'create' && (
+          <NodeCreate
+            cyRef={cyRef}
+            targetNode={targetNode}
+            nodeIdCounter={nodeIdCounter}
+            countNodeIdCounter={countNodeIdCounter}
+            onChangeTargetNode={onChangeTargetNode}
+            initTargetNode={initTargetNode}
+          />
+        )}
+        {currentMode === 'delete' && (
+          <NodeDelete cyRef={cyRef} targetNode={targetNode} />
+        )}
+        {currentMode === 'update' && (
+          <NodeUpdate
+            cyRef={cyRef}
+            targetNode={targetNode}
+            onChangeTargetNode={onChangeTargetNode}
+            initTargetNode={initTargetNode}
+          />
+        )}
       </div>
     </ControlContainer>
   );

--- a/src/components/CytoscapeControl.js
+++ b/src/components/CytoscapeControl.js
@@ -1,3 +1,4 @@
+/* eslint-disable no-console */
 import { useState, useEffect, useRef } from 'react';
 import { useRecoilState } from 'recoil';
 import styled from 'styled-components';
@@ -5,6 +6,7 @@ import styled from 'styled-components';
 import {
   nodeInputState,
   targetNodeInputState,
+  isModeNode,
 } from './globalState/nodeControl';
 import NodeCreate from './graphControls/NodeCreate';
 import NodeDelete from './graphControls/NodeDelete';
@@ -39,20 +41,30 @@ const CytoscapeControl = ({ cyRef }) => {
     { name: '삭제', mode: 'delete' },
   ]);
   const [currentMode, setCurrentMode] = useState('create');
-  // const [newNode, setNewNode] = useRecoilState(nodeInputState);
+  const [inputType, setInputType] = useRecoilState(isModeNode);
+  const [nodeId, setNodeId] = useRecoilState(nodeInputState);
   const [targetNode, setTargetNode] = useRecoilState(targetNodeInputState);
   const nodeIdCounter = useRef(5);
 
+  // CRUD 타입 결정
+  const handleMode = (mode) => {
+    setCurrentMode(mode);
+  };
+
+  // 싱글 노드 이벤트
+  const initNodeId = () => {
+    setNodeId();
+  };
+  const onChangeNodeId = (e) => {
+    setNodeId(e.target.value);
+  };
+
+  // edge 타겟 노드 이벤트
   const initTargetNode = () => {
     setTargetNode('');
   };
-
   const onChangeTargetNode = (e) => {
     setTargetNode(e.target.value);
-  };
-
-  const handleMode = (mode) => {
-    setCurrentMode(mode);
   };
 
   const countNodeIdCounter = () => {
@@ -60,12 +72,18 @@ const CytoscapeControl = ({ cyRef }) => {
   };
 
   useEffect(() => {
+    const cy = cyRef.current;
     // 노드 클릭 이벤트
-    cyRef.current.on('tap', 'node', (e) => {
-      const node = e.target;
-      setTargetNode(node.id());
+    cy.on('tap', 'node', (e) => {
+      if (inputType) {
+        const node = e.target;
+        setNodeId(node.id());
+      } else {
+        const node = e.target;
+        setTargetNode(node.id());
+      }
     });
-  }, [cyRef, setTargetNode]);
+  }, [cyRef, inputType, setNodeId, setTargetNode]);
 
   return (
     <ControlContainer>
@@ -93,11 +111,21 @@ const CytoscapeControl = ({ cyRef }) => {
           />
         )}
         {currentMode === 'delete' && (
-          <NodeDelete cyRef={cyRef} targetNode={targetNode} />
+          <NodeDelete
+            cyRef={cyRef}
+            nodeId={nodeId}
+            onChangeNodeId={onChangeNodeId}
+            initNodeId={initNodeId}
+            targetNode={targetNode}
+            onChangeTargetNode={onChangeTargetNode}
+            initTargetNode={initTargetNode}
+          />
         )}
         {currentMode === 'update' && (
           <NodeUpdate
             cyRef={cyRef}
+            nodeId={nodeId}
+            onChangeNodeId={onChangeNodeId}
             targetNode={targetNode}
             onChangeTargetNode={onChangeTargetNode}
             initTargetNode={initTargetNode}

--- a/src/components/CytoscapeControl.js
+++ b/src/components/CytoscapeControl.js
@@ -1,6 +1,6 @@
 /* eslint-disable no-console */
 import { useState, useEffect, useRef } from 'react';
-import { useRecoilState } from 'recoil';
+import { useRecoilState, useRecoilValue } from 'recoil';
 import styled from 'styled-components';
 
 import {
@@ -41,7 +41,7 @@ const CytoscapeControl = ({ cyRef }) => {
     { name: '삭제', mode: 'delete' },
   ]);
   const [currentMode, setCurrentMode] = useState('create');
-  const [inputType, setInputType] = useRecoilState(isModeNode);
+  const inputType = useRecoilValue(isModeNode);
   const [nodeId, setNodeId] = useRecoilState(nodeInputState);
   const [targetNode, setTargetNode] = useRecoilState(targetNodeInputState);
   const nodeIdCounter = useRef(5);
@@ -76,36 +76,17 @@ const CytoscapeControl = ({ cyRef }) => {
   useEffect(() => {
     const cy = cyRef.current;
     // 노드 클릭 이벤트
-    cy.on('tap', 'node', (e) => {
-      if (inputType) {
-        const node = e.target;
-        setNodeId(node.id());
-      }
-      // else {
-      //   const node = e.target;
-      //   setTargetNode(node.id());
-      // }
-    });
-
-    // if (inputType) {
-    //   console.log('oneStart');
-    //   cy.on('tab', 'node', (e) => {
-    //     console.log('one');
-    //     const node = e.target;
-    //     setNodeId(node.id());
-    //   });
-    // } else {
-    //   cy.one('tab', 'node', (e) => {
-    //     console.log('two1');
-    //     const node = e.target;
-    //     setNodeId(node.id());
-    //   });
-    //   cy.one('tab', 'node', (e) => {
-    //     console.log('two2');
-    //     const node = e.target;
-    //     setTargetNode(node.id());
-    //   });
-    // }
+    const nodeClickHandler = (e) => {
+      const node = e.target;
+      setNodeId(node.id());
+    };
+    if (inputType) {
+      // console.log('추가');
+      cy.on('tap', 'node', nodeClickHandler);
+    } else {
+      // console.log('삭제');
+      cy.removeListener('tap', nodeClickHandler);
+    }
   }, [cyRef, inputType, setNodeId, setTargetNode]);
 
   return (
@@ -126,6 +107,9 @@ const CytoscapeControl = ({ cyRef }) => {
         {currentMode === 'create' && (
           <NodeCreate
             cyRef={cyRef}
+            inputType={inputType}
+            nodeId={nodeId}
+            onChangeNodeId={onChangeNodeId}
             targetNode={targetNode}
             nodeIdCounter={nodeIdCounter}
             countNodeIdCounter={countNodeIdCounter}

--- a/src/components/CytoscapeControl.js
+++ b/src/components/CytoscapeControl.js
@@ -48,6 +48,8 @@ const CytoscapeControl = ({ cyRef }) => {
 
   // CRUD 타입 결정
   const handleMode = (mode) => {
+    setNodeId('');
+    setTargetNode('');
     setCurrentMode(mode);
   };
 
@@ -55,16 +57,16 @@ const CytoscapeControl = ({ cyRef }) => {
   const initNodeId = () => {
     setNodeId();
   };
-  const onChangeNodeId = (e) => {
-    setNodeId(e.target.value);
+  const onChangeNodeId = (value) => {
+    setNodeId(value);
   };
 
   // edge 타겟 노드 이벤트
   const initTargetNode = () => {
     setTargetNode('');
   };
-  const onChangeTargetNode = (e) => {
-    setTargetNode(e.target.value);
+  const onChangeTargetNode = (value) => {
+    setTargetNode(value);
   };
 
   const countNodeIdCounter = () => {
@@ -78,11 +80,32 @@ const CytoscapeControl = ({ cyRef }) => {
       if (inputType) {
         const node = e.target;
         setNodeId(node.id());
-      } else {
-        const node = e.target;
-        setTargetNode(node.id());
       }
+      // else {
+      //   const node = e.target;
+      //   setTargetNode(node.id());
+      // }
     });
+
+    // if (inputType) {
+    //   console.log('oneStart');
+    //   cy.on('tab', 'node', (e) => {
+    //     console.log('one');
+    //     const node = e.target;
+    //     setNodeId(node.id());
+    //   });
+    // } else {
+    //   cy.one('tab', 'node', (e) => {
+    //     console.log('two1');
+    //     const node = e.target;
+    //     setNodeId(node.id());
+    //   });
+    //   cy.one('tab', 'node', (e) => {
+    //     console.log('two2');
+    //     const node = e.target;
+    //     setTargetNode(node.id());
+    //   });
+    // }
   }, [cyRef, inputType, setNodeId, setTargetNode]);
 
   return (

--- a/src/components/globalState/nodeControl.js
+++ b/src/components/globalState/nodeControl.js
@@ -1,0 +1,8 @@
+import { atom } from 'recoil';
+
+const nodeInputState = atom({
+  key: 'nodeInputState',
+  default: '',
+});
+
+export default nodeInputState;

--- a/src/components/globalState/nodeControl.js
+++ b/src/components/globalState/nodeControl.js
@@ -1,8 +1,13 @@
 import { atom } from 'recoil';
 
-const nodeInputState = atom({
+// 노드의 추가, 삭제, 수정시 참조되는 상태
+export const nodeInputState = atom({
   key: 'nodeInputState',
   default: '',
 });
 
-export default nodeInputState;
+// 간선 추가, 삭제시 타겟이 되는 노드의 상태
+export const targetNodeInputState = atom({
+  key: 'targetNodeInputState',
+  default: '',
+});

--- a/src/components/globalState/nodeControl.js
+++ b/src/components/globalState/nodeControl.js
@@ -11,3 +11,9 @@ export const targetNodeInputState = atom({
   key: 'targetNodeInputState',
   default: '',
 });
+
+// 노드 모드인지 판단
+export const isModeNode = atom({
+  key: 'isModeNode',
+  default: true,
+});

--- a/src/components/graphControls/NodeCreate.js
+++ b/src/components/graphControls/NodeCreate.js
@@ -18,7 +18,6 @@ const NodeCreate = ({
   countNodeIdCounter,
 }) => {
   const [insertType, setInsertType] = useRecoilState(isModeNode);
-  // const [insertType, setInsertType] = useState(true);
   const [newNode, setNewNode] = useState('');
   let isExist = true;
 
@@ -78,7 +77,6 @@ const NodeCreate = ({
   // 입력모드 변경 이벤트
   const changeInsertMode = () => {
     setNewNode('');
-    initTargetNode();
     setInsertType(!insertType);
   };
 

--- a/src/components/graphControls/NodeCreate.js
+++ b/src/components/graphControls/NodeCreate.js
@@ -1,6 +1,9 @@
 /* eslint-disable no-alert */
 import { useState } from 'react';
+import { useRecoilState } from 'recoil';
 import styled from 'styled-components';
+
+import { isModeNode } from '../globalState/nodeControl';
 
 const InputGraph = styled.input`
   /* width: 300px; */
@@ -14,7 +17,8 @@ const NodeCreate = ({
   nodeIdCounter,
   countNodeIdCounter,
 }) => {
-  const [insertType, setInsertType] = useState(true);
+  const [insertType, setInsertType] = useRecoilState(isModeNode);
+  // const [insertType, setInsertType] = useState(true);
   const [newNode, setNewNode] = useState('');
   let isExist = true;
 

--- a/src/components/graphControls/NodeCreate.js
+++ b/src/components/graphControls/NodeCreate.js
@@ -91,6 +91,7 @@ const NodeCreate = ({
   };
 
   // edge 추가 포커스 이벤트
+  // 간혈적으로 source와 target 동시 수정되는 문제 해결 필요
   const onFocusToNode = (h) => {
     if (insertType === false) {
       cyRef.current.on('tap', 'node', (e) => {

--- a/src/components/graphControls/NodeCreate.js
+++ b/src/components/graphControls/NodeCreate.js
@@ -1,5 +1,6 @@
+/* eslint-disable no-console */
 /* eslint-disable no-alert */
-import { useState } from 'react';
+import { useState, useRef } from 'react';
 import styled from 'styled-components';
 
 const InputGraph = styled.input`
@@ -10,7 +11,10 @@ const NodeCreate = ({ cyRef }) => {
   const [insertType, setInsertType] = useState(true);
   const [newNode, setNewNode] = useState('');
   const [targetNode, setTargetNode] = useState('');
-  let isExist = false;
+  const nodeIdCounter = useRef(5);
+
+  // let isExist = false;
+  let isExist = true;
 
   // form 내용 변경 감지
   const onChangeNewNode = (e) => {
@@ -42,7 +46,7 @@ const NodeCreate = ({ cyRef }) => {
   const onNewGraph = (e) => {
     const item = {
       data: {
-        id: newNode,
+        id: nodeIdCounter.current,
         label: newNode,
       },
       position: {
@@ -51,12 +55,8 @@ const NodeCreate = ({ cyRef }) => {
       },
     };
     e.preventDefault();
-    insertIsExist(item);
-    if (isExist) {
-      cyRef.current.add(item);
-    } else {
-      alert(`${item.data.id}은/는 이미 존재합니다`);
-    }
+    cyRef.current.add(item);
+    nodeIdCounter.current += 1;
     setNewNode('');
   };
 

--- a/src/components/graphControls/NodeCreate.js
+++ b/src/components/graphControls/NodeCreate.js
@@ -19,6 +19,7 @@ const NodeCreate = ({
   initTargetNode,
   nodeIdCounter,
   countNodeIdCounter,
+  nodeClickHandler,
 }) => {
   const [insertType, setInsertType] = useRecoilState(isModeNode);
   const [newNode, setNewNode] = useState('');
@@ -91,7 +92,6 @@ const NodeCreate = ({
   };
 
   // edge 추가 포커스 이벤트
-  // 간혈적으로 source와 target 동시 수정되는 문제 해결 필요
   const onFocusToNode = (h) => {
     if (insertType === false) {
       cyRef.current.on('tap', 'node', (e) => {
@@ -106,6 +106,15 @@ const NodeCreate = ({
       });
     }
   };
+
+  // edge 연결시 nodeClickHandler가 계속 활성화 되는 상태를 막음
+  useEffect(() => {
+    const cy = cyRef.current;
+    cy.removeListener('tap', nodeClickHandler);
+    return () => {
+      cy.on('tap', 'node', nodeClickHandler);
+    };
+  }, [cyRef, nodeClickHandler]);
 
   return (
     <div>

--- a/src/components/graphControls/NodeCreate.js
+++ b/src/components/graphControls/NodeCreate.js
@@ -1,5 +1,6 @@
+/* eslint-disable no-console */
 /* eslint-disable no-alert */
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { useRecoilState } from 'recoil';
 import styled from 'styled-components';
 
@@ -11,6 +12,8 @@ const InputGraph = styled.input`
 
 const NodeCreate = ({
   cyRef,
+  nodeId,
+  onChangeNodeId,
   targetNode,
   onChangeTargetNode,
   initTargetNode,
@@ -24,6 +27,13 @@ const NodeCreate = ({
   // form 내용 변경 감지
   const onChangeNewNode = (e) => {
     setNewNode(e.target.value);
+  };
+
+  const onChangeToNode = (value) => {
+    onChangeNodeId(value);
+  };
+  const onChangeFromNode = (value) => {
+    onChangeTargetNode(value);
   };
 
   // 존재유무판단
@@ -58,16 +68,16 @@ const NodeCreate = ({
   const onConnectGraph = (e) => {
     const newConnect = {
       data: {
-        source: newNode,
+        source: nodeId,
         target: targetNode,
-        label: `edge from ${newNode} to ${targetNode}`,
+        label: `edge from ${nodeId} to ${targetNode}`,
       },
     };
     e.preventDefault();
-    insertIsExist(newNode, targetNode);
+    insertIsExist(nodeId, targetNode);
     if (isExist) {
       cyRef.current.add(newConnect);
-      setNewNode('');
+      onChangeToNode('');
       initTargetNode();
     } else {
       alert(`입력값을 다시 확인해주세요`);
@@ -78,6 +88,22 @@ const NodeCreate = ({
   const changeInsertMode = () => {
     setNewNode('');
     setInsertType(!insertType);
+  };
+
+  // edge 추가 포커스 이벤트
+  const onFocusToNode = (h) => {
+    if (insertType === false) {
+      cyRef.current.on('tap', 'node', (e) => {
+        const node = e.target;
+        if (h.target.name === 'startNode') {
+          cyRef.current.removeListener('tap', 'node');
+          onChangeToNode(node.id());
+        } else {
+          cyRef.current.removeListener('tap', 'node');
+          onChangeFromNode(node.id());
+        }
+      });
+    }
   };
 
   return (
@@ -104,14 +130,18 @@ const NodeCreate = ({
           <InputGraph
             type='text'
             placeholder='시작요소'
-            value={newNode}
-            onChange={onChangeNewNode}
+            value={nodeId}
+            onChange={onChangeToNode}
+            onFocus={onFocusToNode}
+            name='startNode'
           />
           <InputGraph
             type='text'
             placeholder='타겟요소'
             value={targetNode}
-            onChange={onChangeTargetNode}
+            onChange={onChangeFromNode}
+            onFocus={onFocusToNode}
+            name='endNode'
           />
           <button type='submit' label='test'>
             연결하기

--- a/src/components/graphControls/NodeCreate.js
+++ b/src/components/graphControls/NodeCreate.js
@@ -1,45 +1,36 @@
-/* eslint-disable no-console */
 /* eslint-disable no-alert */
-import { useState, useRef } from 'react';
+import { useState } from 'react';
 import styled from 'styled-components';
 
 const InputGraph = styled.input`
   /* width: 300px; */
 `;
 
-const NodeCreate = ({ cyRef }) => {
+const NodeCreate = ({
+  cyRef,
+  targetNode,
+  onChangeTargetNode,
+  initTargetNode,
+  nodeIdCounter,
+  countNodeIdCounter,
+}) => {
   const [insertType, setInsertType] = useState(true);
   const [newNode, setNewNode] = useState('');
-  const [targetNode, setTargetNode] = useState('');
-  const nodeIdCounter = useRef(5);
-
-  // let isExist = false;
   let isExist = true;
 
   // form 내용 변경 감지
   const onChangeNewNode = (e) => {
     setNewNode(e.target.value);
   };
-  const onChangeTargetNode = (e) => {
-    setTargetNode(e.target.value);
-  };
 
   // 존재유무판단
   const insertIsExist = (...item) => {
-    if (item.length === 1) {
-      if (cyRef.current.getElementById(item[0].data.label).length === 0) {
-        isExist = true;
-      } else {
+    isExist = true;
+    item.forEach((node) => {
+      if (cyRef.current.getElementById(node).length === 0) {
         isExist = false;
       }
-    } else if (item.length === 2) {
-      isExist = true;
-      item.forEach((node) => {
-        if (cyRef.current.getElementById(node).length === 0) {
-          isExist = false;
-        }
-      });
-    }
+    });
   };
 
   // 노드 추가 이벤트
@@ -56,7 +47,7 @@ const NodeCreate = ({ cyRef }) => {
     };
     e.preventDefault();
     cyRef.current.add(item);
-    nodeIdCounter.current += 1;
+    countNodeIdCounter();
     setNewNode('');
   };
 
@@ -74,7 +65,7 @@ const NodeCreate = ({ cyRef }) => {
     if (isExist) {
       cyRef.current.add(newConnect);
       setNewNode('');
-      setTargetNode('');
+      initTargetNode();
     } else {
       alert(`입력값을 다시 확인해주세요`);
     }
@@ -83,7 +74,7 @@ const NodeCreate = ({ cyRef }) => {
   // 입력모드 변경 이벤트
   const changeInsertMode = () => {
     setNewNode('');
-    setTargetNode('');
+    initTargetNode();
     setInsertType(!insertType);
   };
 

--- a/src/components/graphControls/NodeDelete.js
+++ b/src/components/graphControls/NodeDelete.js
@@ -1,5 +1,5 @@
 /* eslint-disable no-console */
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import { useRecoilState } from 'recoil';
 
 import { isModeNode } from '../globalState/nodeControl';
@@ -28,7 +28,6 @@ const NodeDelete = ({
 
   const changeMode = () => {
     initNode();
-    // setTargetNode('');
     setRemoveType(!removeType);
   };
 
@@ -45,9 +44,24 @@ const NodeDelete = ({
     e.preventDefault();
     cyRef.current.remove(`edge[source = "${nodeId}"][target= "${targetNode}"]`);
     initNode();
-    // setTargetNode('');
     initTargetNode();
   };
+
+  useEffect(() => {
+    const cy = cyRef.current;
+    // 간선 삭제 컨트롤
+    if (removeType === false) {
+      cy.removeListener('tap', 'node');
+      cy.on('tap', 'edge', (e) => {
+        const edge = e.target;
+        onChangeNodeId(edge.data().source);
+        onChangeTargetNode(edge.data().target);
+      });
+    }
+    return () => {
+      cy.removeListener('tap', 'edge');
+    };
+  }, [cyRef, removeType, onChangeNodeId, onChangeTargetNode]);
 
   return (
     <>

--- a/src/components/graphControls/NodeDelete.js
+++ b/src/components/graphControls/NodeDelete.js
@@ -1,41 +1,52 @@
 /* eslint-disable no-console */
 import { useState } from 'react';
+import { useRecoilState } from 'recoil';
 
-const NodeDelete = ({ cyRef }) => {
-  const [removeNode, setRemoveNode] = useState('');
-  const [targetNode, setTargetNode] = useState('');
-  const [removeType, setRemoveType] = useState(true);
+import { isModeNode } from '../globalState/nodeControl';
+
+const NodeDelete = ({
+  cyRef,
+  nodeId,
+  onChangeNodeId,
+  initNodeId,
+  targetNode,
+  onChangeTargetNode,
+  initTargetNode,
+}) => {
+  const [removeType, setRemoveType] = useRecoilState(isModeNode);
 
   const onChangeRemoveNode = (e) => {
-    setRemoveNode(e.target.value);
+    onChangeNodeId(e.target.value);
   };
-  const onChangeTargetNode = (e) => {
-    setTargetNode(e.target.value);
+  const initNode = () => {
+    initNodeId();
+  };
+
+  const onChangeConnectNode = (e) => {
+    onChangeTargetNode(e.target.value);
   };
 
   const changeMode = () => {
-    setRemoveNode('');
-    setTargetNode('');
+    initNode();
+    // setTargetNode('');
     setRemoveType(!removeType);
   };
 
   // 노드 삭제 이벤트
   const onRemoveNode = (e) => {
     e.preventDefault();
-    const findNode = cyRef.current.$(`[id = "${removeNode}"]`);
+    const findNode = cyRef.current.$(`[id = "${nodeId}"]`);
     cyRef.current.remove(findNode);
-    setRemoveNode('');
+    initNode();
   };
 
   // edge삭제 이벤트
   const onRemoveEdge = (e) => {
     e.preventDefault();
-    // some Evnet occur
-    cyRef.current.remove(
-      `edge[source = "${removeNode}"][target= "${targetNode}"]`,
-    );
-    setRemoveNode('');
-    setTargetNode('');
+    cyRef.current.remove(`edge[source = "${nodeId}"][target= "${targetNode}"]`);
+    initNode();
+    // setTargetNode('');
+    initTargetNode();
   };
 
   return (
@@ -45,11 +56,13 @@ const NodeDelete = ({ cyRef }) => {
       </button>
       {removeType ? (
         <form onSubmit={onRemoveNode}>
+          <p>선택된 id : {nodeId}</p>
           <input
             type='text'
-            value={removeNode}
+            value={nodeId || ''}
             onChange={onChangeRemoveNode}
             placeholder='삭제할 노드를 선택하세요'
+            hidden
           />
           <button type='submit' label='test'>
             삭제하기
@@ -59,14 +72,14 @@ const NodeDelete = ({ cyRef }) => {
         <form onSubmit={onRemoveEdge}>
           <input
             type='text'
-            value={removeNode}
+            value={nodeId || ''}
             onChange={onChangeRemoveNode}
             placeholder='From'
           />
           <input
             type='text'
-            value={targetNode}
-            onChange={onChangeTargetNode}
+            value={targetNode || ''}
+            onChange={onChangeConnectNode}
             placeholder='To'
           />
           <button type='submit' label='test'>

--- a/src/components/graphControls/NodeUpdate.js
+++ b/src/components/graphControls/NodeUpdate.js
@@ -1,20 +1,28 @@
 import { useState } from 'react';
+import { useRecoilState } from 'recoil';
+
+import { isModeNode } from '../globalState/nodeControl';
 
 const NodeUpdate = ({
   cyRef,
+  nodeId,
+  onChangeNodeId,
   targetNode,
   onChangeTargetNode,
   initTargetNode,
 }) => {
   const [updateName, setUpdateName] = useState('');
-  const [updateType, setUpdateType] = useState(true);
+  const [updateType, setUpdateType] = useRecoilState(isModeNode);
+
+  const onChangeNode = (e) => {
+    onChangeNodeId(e.target.value);
+  };
 
   const onChangeUpdateName = (e) => {
     setUpdateName(e.target.value);
   };
 
   const changeMode = () => {
-    initTargetNode();
     setUpdateName('');
     setUpdateType(!updateType);
   };
@@ -22,9 +30,8 @@ const NodeUpdate = ({
   // 노드 수정 이벤트
   const onUpdateNode = (e) => {
     e.preventDefault();
-    const findNode = cyRef.current.$(`[id = "${targetNode}"]`);
+    const findNode = cyRef.current.$(`[id = "${nodeId}"]`);
     findNode.data('label', updateName);
-    initTargetNode();
     setUpdateName('');
   };
 
@@ -35,11 +42,11 @@ const NodeUpdate = ({
       </button>
       {updateType ? (
         <form onSubmit={onUpdateNode}>
-          <p>바꿀 노드 id: {targetNode} </p>
+          <p>바꿀 노드 id: {nodeId} </p>
           <input
             type='text'
-            value={targetNode}
-            onChange={onChangeTargetNode}
+            value={nodeId}
+            onChange={onChangeNode}
             placeholder='수정할 노드 이름'
             hidden='hidden'
           />

--- a/src/components/graphControls/NodeUpdate.js
+++ b/src/components/graphControls/NodeUpdate.js
@@ -1,11 +1,11 @@
-/* eslint-disable no-console */
-import { useState, useEffect } from 'react';
-import { useRecoilState } from 'recoil';
+import { useState } from 'react';
 
-import nodeInputState from '../globalState/nodeControl';
-
-const NodeDelete = ({ cyRef }) => {
-  const [updateNode, setUpdateNode] = useRecoilState(nodeInputState);
+const NodeUpdate = ({
+  cyRef,
+  targetNode,
+  onChangeTargetNode,
+  initTargetNode,
+}) => {
   const [updateName, setUpdateName] = useState('');
   const [updateType, setUpdateType] = useState(true);
 
@@ -13,21 +13,8 @@ const NodeDelete = ({ cyRef }) => {
     setUpdateName(e.target.value);
   };
 
-  useEffect(() => {
-    // 노드 클릭 이벤트
-    cyRef.current.on('tap', 'node', (e) => {
-      const node = e.target;
-      setUpdateNode(node.id());
-      console.log(node.data().label);
-    });
-  }, [cyRef, setUpdateNode]);
-
-  const onChangeUpdateNode = (e) => {
-    setUpdateNode(e.target.value);
-  };
-
   const changeMode = () => {
-    setUpdateNode('');
+    initTargetNode();
     setUpdateName('');
     setUpdateType(!updateType);
   };
@@ -35,11 +22,10 @@ const NodeDelete = ({ cyRef }) => {
   // 노드 수정 이벤트
   const onUpdateNode = (e) => {
     e.preventDefault();
-    const findNode = cyRef.current.$(`[id = "${updateNode}"]`);
+    const findNode = cyRef.current.$(`[id = "${targetNode}"]`);
     findNode.data('label', updateName);
-    setUpdateNode('');
+    initTargetNode();
     setUpdateName('');
-    // console.log(cyRef.current.$('*'));
   };
 
   return (
@@ -49,11 +35,11 @@ const NodeDelete = ({ cyRef }) => {
       </button>
       {updateType ? (
         <form onSubmit={onUpdateNode}>
-          <p>바꿀 노드 id: {updateNode} </p>
+          <p>바꿀 노드 id: {targetNode} </p>
           <input
             type='text'
-            value={updateNode}
-            onChange={onChangeUpdateNode}
+            value={targetNode}
+            onChange={onChangeTargetNode}
             placeholder='수정할 노드 이름'
             hidden='hidden'
           />
@@ -74,4 +60,4 @@ const NodeDelete = ({ cyRef }) => {
   );
 };
 
-export default NodeDelete;
+export default NodeUpdate;

--- a/src/components/graphControls/NodeUpdate.js
+++ b/src/components/graphControls/NodeUpdate.js
@@ -1,16 +1,29 @@
 /* eslint-disable no-console */
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
+import { useRecoilState } from 'recoil';
+
+import nodeInputState from '../globalState/nodeControl';
 
 const NodeDelete = ({ cyRef }) => {
-  const [updateNode, setUpdateNode] = useState('');
+  const [updateNode, setUpdateNode] = useRecoilState(nodeInputState);
   const [updateName, setUpdateName] = useState('');
   const [updateType, setUpdateType] = useState(true);
 
-  const onChangeUpdateNode = (e) => {
-    setUpdateNode(e.target.value);
-  };
   const onChangeUpdateName = (e) => {
     setUpdateName(e.target.value);
+  };
+
+  useEffect(() => {
+    // 노드 클릭 이벤트
+    cyRef.current.on('tap', 'node', (e) => {
+      const node = e.target;
+      setUpdateNode(node.id());
+      console.log(node.data().label);
+    });
+  }, [cyRef, setUpdateNode]);
+
+  const onChangeUpdateNode = (e) => {
+    setUpdateNode(e.target.value);
   };
 
   const changeMode = () => {
@@ -23,11 +36,10 @@ const NodeDelete = ({ cyRef }) => {
   const onUpdateNode = (e) => {
     e.preventDefault();
     const findNode = cyRef.current.$(`[id = "${updateNode}"]`);
-    findNode.data('id', updateName);
     findNode.data('label', updateName);
     setUpdateNode('');
     setUpdateName('');
-    console.log(cyRef.current.$('*'));
+    // console.log(cyRef.current.$('*'));
   };
 
   return (
@@ -37,11 +49,13 @@ const NodeDelete = ({ cyRef }) => {
       </button>
       {updateType ? (
         <form onSubmit={onUpdateNode}>
+          <p>바꿀 노드 id: {updateNode} </p>
           <input
             type='text'
             value={updateNode}
             onChange={onChangeUpdateNode}
             placeholder='수정할 노드 이름'
+            hidden='hidden'
           />
           <input
             type='text'

--- a/src/components/graphControls/NodeUpdate.js
+++ b/src/components/graphControls/NodeUpdate.js
@@ -1,18 +1,7 @@
 import { useState } from 'react';
-import { useRecoilState } from 'recoil';
 
-import { isModeNode } from '../globalState/nodeControl';
-
-const NodeUpdate = ({
-  cyRef,
-  nodeId,
-  onChangeNodeId,
-  targetNode,
-  onChangeTargetNode,
-  initTargetNode,
-}) => {
+const NodeUpdate = ({ cyRef, nodeId, onChangeNodeId }) => {
   const [updateName, setUpdateName] = useState('');
-  const [updateType, setUpdateType] = useRecoilState(isModeNode);
 
   const onChangeNode = (e) => {
     onChangeNodeId(e.target.value);
@@ -20,11 +9,6 @@ const NodeUpdate = ({
 
   const onChangeUpdateName = (e) => {
     setUpdateName(e.target.value);
-  };
-
-  const changeMode = () => {
-    setUpdateName('');
-    setUpdateType(!updateType);
   };
 
   // 노드 수정 이벤트
@@ -36,34 +20,25 @@ const NodeUpdate = ({
   };
 
   return (
-    <>
-      <button type='button' onClick={changeMode}>
-        모드변경하기
+    <form onSubmit={onUpdateNode}>
+      <p>바꿀 노드 id: {nodeId} </p>
+      <input
+        type='text'
+        value={nodeId}
+        onChange={onChangeNode}
+        placeholder='수정할 노드 이름'
+        hidden='hidden'
+      />
+      <input
+        type='text'
+        value={updateName}
+        onChange={onChangeUpdateName}
+        placeholder='새로운 이름'
+      />
+      <button type='submit' label='test'>
+        수정하기
       </button>
-      {updateType ? (
-        <form onSubmit={onUpdateNode}>
-          <p>바꿀 노드 id: {nodeId} </p>
-          <input
-            type='text'
-            value={nodeId}
-            onChange={onChangeNode}
-            placeholder='수정할 노드 이름'
-            hidden='hidden'
-          />
-          <input
-            type='text'
-            value={updateName}
-            onChange={onChangeUpdateName}
-            placeholder='새로운 이름'
-          />
-          <button type='submit' label='test'>
-            수정하기
-          </button>
-        </form>
-      ) : (
-        <p>다른모드</p>
-      )}
-    </>
+    </form>
   );
 };
 

--- a/src/page/MindMap.js
+++ b/src/page/MindMap.js
@@ -1,4 +1,5 @@
-import { useRef } from 'react';
+/* eslint-disable no-console */
+import { useEffect, useRef } from 'react';
 import CytoscapeComponent from 'react-cytoscapejs';
 import styled from 'styled-components';
 
@@ -117,6 +118,14 @@ const MindMap = () => {
   };
   // cytoscape DOM을 다루기 위한 ref
   const cyRef = useRef();
+
+  useEffect(() => {
+    // node click event
+    cyRef.current.on('tap', 'node', (evt) => {
+      const node = evt.target;
+      console.log(`tapped ${node.id()}`);
+    });
+  }, [cyRef]);
 
   // 노드 연결 기능 구현필요
   return (

--- a/src/page/MindMap.js
+++ b/src/page/MindMap.js
@@ -26,28 +26,8 @@ const MindMap = () => {
     nodes: [
       {
         data: {
-          id: 'Node 1',
-          label: 'Node 1',
-        },
-        position: {
-          x: 640,
-          y: 360,
-        },
-      },
-      {
-        data: {
-          id: 'Node 3',
-          label: 'Node 3',
-        },
-        position: {
-          x: 540,
-          y: 360,
-        },
-      },
-      {
-        data: {
           id: '1',
-          label: '1',
+          label: '노드1',
         },
         position: {
           x: 340,
@@ -57,7 +37,7 @@ const MindMap = () => {
       {
         data: {
           id: '2',
-          label: '2',
+          label: '노드2',
         },
         position: {
           x: 440,
@@ -67,7 +47,7 @@ const MindMap = () => {
       {
         data: {
           id: '3',
-          label: '3',
+          label: '노드3',
         },
         position: {
           x: 140,
@@ -77,7 +57,7 @@ const MindMap = () => {
       {
         data: {
           id: '4',
-          label: '4',
+          label: '노드4',
         },
         position: {
           x: 240,
@@ -86,13 +66,6 @@ const MindMap = () => {
       },
     ],
     edges: [
-      {
-        data: {
-          source: 'Node 1',
-          target: 'Node 3',
-          label: 'edge from node1 to node3',
-        },
-      },
       {
         data: {
           source: '1',

--- a/src/page/MindMap.js
+++ b/src/page/MindMap.js
@@ -116,16 +116,9 @@ const MindMap = () => {
       },
     ],
   };
+
   // cytoscape DOM을 다루기 위한 ref
   const cyRef = useRef();
-
-  useEffect(() => {
-    // node click event
-    cyRef.current.on('tap', 'node', (evt) => {
-      const node = evt.target;
-      console.log(`tapped ${node.id()}`);
-    });
-  }, [cyRef]);
 
   // 노드 연결 기능 구현필요
   return (

--- a/yarn.lock
+++ b/yarn.lock
@@ -5561,6 +5561,11 @@ gzip-size@5.1.1:
     duplexer "^0.1.1"
     pify "^4.0.1"
 
+hamt_plus@1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/hamt_plus/-/hamt_plus-1.0.2.tgz#e21c252968c7e33b20f6a1b094cd85787a265601"
+  integrity sha1-4hwlKWjH4zsg9qGwlM2FeHomVgE=
+
 handle-thing@^2.0.0:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/handle-thing/-/handle-thing-2.0.1.tgz#857f79ce359580c340d43081cc648970d0bb234e"
@@ -9497,6 +9502,13 @@ readdirp@~3.6.0:
   integrity sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==
   dependencies:
     picomatch "^2.2.1"
+
+recoil@^0.5.2:
+  version "0.5.2"
+  resolved "https://registry.yarnpkg.com/recoil/-/recoil-0.5.2.tgz#61fecce3b4dc91127a595586cf7369e2811ba024"
+  integrity sha512-Edibzpu3dbUMLy6QRg73WL8dvMl9Xqhp+kU+f2sJtXxsaXvAlxU/GcnDE8HXPkprXrhHF2e6SZozptNvjNF5fw==
+  dependencies:
+    hamt_plus "1.0.2"
 
 recursive-readdir@2.2.2:
   version "2.2.2"


### PR DESCRIPTION
노드 및 간선 추가 기능 구현 중 id의 immutable을 고려하지 않은 설정으로 인한 설계미스를 발견했습니다

변경점
1. id immutable 속성을 지키기 위해 Create, Update, Delete 기능을 수정합니다
2. 노드 및 간선 이벤트 방식을 리팩토링합니다
    - input에 직접 입력하는 방식 => 마우스를 통한 방식
3. 기타 버그를 수정합니다